### PR TITLE
remove library design from instructions for now

### DIFF
--- a/workshop/6-libraries.md
+++ b/workshop/6-libraries.md
@@ -12,8 +12,9 @@ barcodes_ (primers) and QC information.
 1. A table will appear. Enter the library information:
   * _Description_: Library #, where # is the sample number
   * _Platform_: Illumina
-  * _Type_: Mate Pair
-  * _Library Design_: WG
+  * _Type_: Paired End
+  * _Selection_: PCR
+  * _Strategy_: WGS
   * _Barcode Kit_: Nextera Dual Index
   * _Index 1_ and _Index 2_: Select any indices you wish
   * _Volume_: 100


### PR DESCRIPTION
- also adds in selection and strategy, as they are required fields (I've filed a ticket to make sure they get indicated as required fields in the UI, as right now they don't go red when you try saving without filling them in)
