### PR TITLE
Change terminology to match updates to MISO

### DIFF
--- a/_includes/index-checking.md
+++ b/_includes/index-checking.md
@@ -15,12 +15,12 @@ you identify indices which may be inadvisable to multiplex together.
    ```
    AAAAAAAA
    AAAAAACC
-   CAAAAAAA
+   CCAAAACC
    AAAAAAAA
    ```
    
 1. Click _Calculate_. The results pane will show you that there is a duplicate (AAAAAAAA),
-   and that two of the sequences are a near match, only differing by 1 base. (AAAAAAAA and
+   and that two of the sequences are a near match, only differing by 2 bases. (AAAAAAAA and
    CAAAAAAA).
 
 <a name="index-distance-length" href="#">top</a>

--- a/_includes/index-checking.md
+++ b/_includes/index-checking.md
@@ -14,14 +14,14 @@ you identify indices which may be inadvisable to multiplex together.
 
    ```
    AAAAAAAA
-   AAAAAACC
-   CCAAAACC
+   AAAAACCC
+   CCAAACCC
    AAAAAAAA
    ```
    
 1. Click _Calculate_. The results pane will show you that there is a duplicate (AAAAAAAA),
-   and that two of the sequences are a near match, only differing by 2 bases. (AAAAAAAA and
-   CAAAAAAA).
+   and that two of the sequences are a near match, only differing by 2 bases. (AAAAACCC and
+   CCAAACCC).
 
 <a name="index-distance-length" href="#">top</a>
 


### PR DESCRIPTION
It turns out there were no instances of "edit distance" in the walkthroughs to be removed, but the default warning level for index mismatches is being changed to 2 bases, and 1 mismatch will be treated as duplicate indices. Corresponds to MISO PR [#2016](https://github.com/miso-lims/miso-lims/pull/2016)